### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "itspriddle/wp-cli-tgmpa-plugin",
   "description": "Manage TGMPA plugins with WP-CLI",
+  "type": "wp-cli-package",
   "license": "MIT",
   "homepage": "https://github.com/itspriddle/wp-cli-tgmpa-plugin",
   "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567