### PR TITLE
Improve TGM_Plugin_Activation initialization

### DIFF
--- a/command.php
+++ b/command.php
@@ -67,7 +67,14 @@ class WP_CLI_TGMPA_Plugin extends WP_CLI_Command {
 
     do_action("tgmpa_register");
 
-    $this->tgmpa = TGM_Plugin_Activation::get_instance();
+    if (method_exists("TGM_Plugin_Activation", "get_instance")) {
+      // TGMPA >= 2.4.0
+      $this->tgmpa = TGM_Plugin_Activation::get_instance();
+    } else {
+      // TGMPA < 2.4.0
+      $this->tgmpa = TGM_Plugin_Activation::$instance;
+    }
+
     $this->tgmpa->populate_file_path();
 
     $installed_plugins = get_plugins();

--- a/command.php
+++ b/command.php
@@ -65,6 +65,10 @@ class WP_CLI_TGMPA_Plugin extends WP_CLI_Command {
       WP_CLI::error("TGM_Plugin_Activation not loaded!");
     }
 
+    if (!has_action("tgmpa_register")) {
+      WP_CLI::error("tgmpa_register hook not found!");
+    }
+
     do_action("tgmpa_register");
 
     if (method_exists("TGM_Plugin_Activation", "get_instance")) {

--- a/features/steps/given-supplemental.php
+++ b/features/steps/given-supplemental.php
@@ -20,3 +20,13 @@ $steps->Given("/^I have TGMPA installed$/", function($world) {
 
   $world->proc("cd {$dir} && zip -r {$dest} {$source}")->run_check();
 });
+
+$steps->Given("/^tgmpa_register is not set$/", function($world) {
+  $tgmpa = $world->variables["RUN_DIR"] . "/wp-content/mu-plugins/tgmpa-example.php";
+
+  // Simulate missing action
+  $disable = "\n\nremove_action('tgmpa_register', 'example_tgmpa_register_required_plugins');";
+  $content = file_get_contents($tgmpa) . $disable;
+
+  file_put_contents($tgmpa, $content);
+});

--- a/features/tgmpa-plugin.feature
+++ b/features/tgmpa-plugin.feature
@@ -10,6 +10,19 @@ Feature: Test that the tgmpa-plugin package works
       """
 
 
+  Scenario: TGM_Plugin_Activation class is not loaded
+    Given a WP install
+    And I have TGMPA installed
+    But tgmpa_register is not set
+
+    When I try `wp tgmpa-plugin info`
+    Then the return code should be 1
+    Then STDERR should be:
+      """
+      Error: tgmpa_register hook not found!
+      """
+
+
   Scenario: TGM_Plugin_Activation class is loaded
     Given a WP install
     And I have TGMPA installed


### PR DESCRIPTION
* Handle missing tgmpa_register action better: if this is missing nothing is going to work, so bail early and let the user know.
* Work around missing `TGM_Plugin_Activation::get_instance()`: TGM_Plugin_Activation 2.3.x and below don't have this method, but it seems we can rely on `TGM_Plugin_Activation::$instance`. This is probably safe to use in newer TGM_Plugin_Activation (2.4 and better), but I'd rather use the proper interface for it in case any logic is added to `get_instance()` in the future.