### PR TITLE
Work around PHP notice with WP_ADMIN flag

### DIFF
--- a/command.php
+++ b/command.php
@@ -696,6 +696,7 @@ class WP_CLI_TGMPA_Plugin extends WP_CLI_Command {
 WP_CLI::add_hook("before_wp_config_load", function() {
   if (!defined("WP_ADMIN") && getenv("WP_ADMIN")) {
     define("WP_ADMIN", true);
+    $_SERVER["PHP_SELF"] = "/wp-admin/index.php";
     WP_CLI::debug("defined WP_ADMIN");
   }
 });


### PR DESCRIPTION
Recent WP seems to emit a notice:

```
% WP_ADMIN=true wp eval 'var_dump(WP_ADMIN);'
Notice: Undefined offset: 1 in /Users/priddle/work/wordpress-playground/public/wp-includes/vars.php on line 31
bool(true)
```